### PR TITLE
feat: allow user to manage feature_flag_called event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+- feat: allow user to manage feature_flag_called event ([#392](https://github.com/PostHog/posthog-ios/pull/392))
+- fix: move the feature_flag_called event filter to a better location (after the events filter) ([#392](https://github.com/PostHog/posthog-ios/pull/392))
+
 ## 3.35.0 - 2025-11-07
 
 - fix: call the flags api with the correct groups key name (the api has a back compatible fix already) ([#389](https://github.com/PostHog/posthog-ios/pull/389))


### PR DESCRIPTION
## :bulb: Motivation and Context
My change addresses the behavior of sticky feature flags from [this PostHog tutorial](https://posthog.com/tutorials/sticky-feature-flags). When initially reading and assigning feature flags to a user, I want to avoid sending the $feature_flag_called event, since these evaluations are not real exposures yet.
If I filter out these events using the beforeSend block, I lose all analytics related to feature flag exposures—including the ones I actually want to track. This approach also breaks experiment accuracy, because I can no longer trigger exposure events exactly when needed.
My update ensures that exposure events are sent only at the appropriate time, keeping experiment tracking reliable and analytics data clean.


## :green_heart: How did you test it?
Unit tests, manual testing in own app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
